### PR TITLE
feat: add South Africa (ZA) to Amazon Marketplace enums

### DIFF
--- a/src/amazon-marketplace.ts
+++ b/src/amazon-marketplace.ts
@@ -81,6 +81,7 @@ export enum AmazonMarketplaceAdvertisingCountryCode {
   TR = 'TR',
   UK = 'UK', // Not a real country code, but such is life. See https://github.com/ScaleLeap/amazon-marketplaces/issues/122
   US = 'US',
+  ZA = 'ZA',
 }
 
 /**
@@ -103,6 +104,7 @@ export enum AmazonMarketplaceAdvertisingTimeZone {
   EUROPE_PARIS = 'Europe/Paris',
   EUROPE_STOCKHOLM = 'Europe/Stockholm',
   EUROPE_WARSAW = 'Europe/Warsaw',
+  AFRICA_JOHANNESBURG = 'Africa/Johannesburg',
 }
 
 export enum AmazonMarketplaceTimeZone {


### PR DESCRIPTION
Add South African country code and timezone to AmazonMarketplaceAdvertisingCountryCode and AmazonMarketplaceAdvertisingTimeZone enums